### PR TITLE
Remove environment checking on command execution

### DIFF
--- a/src/ConfigValueSet.php
+++ b/src/ConfigValueSet.php
@@ -52,4 +52,9 @@ class ConfigValueSet implements \IteratorAggregate
     private function __construct()
     {
     }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->values);
+    }
 }

--- a/src/EnvironmentConfigurationCommand.php
+++ b/src/EnvironmentConfigurationCommand.php
@@ -43,15 +43,6 @@ class EnvironmentConfigurationCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $environment = $input->getArgument('environment');
-
-        if (!Environment::isValid($environment)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Specified environment %s is invalid, accepted environments are %s.',
-                $environment,
-                implode(', ', Environment::all())
-            ));
-        }
-
         $environmentValues = $this
             ->environmentConfigValuesProvider
             ->getValues()
@@ -62,10 +53,16 @@ class EnvironmentConfigurationCommand extends Command
             $this->configValueRepository->save($configValue);
         }
 
-        $output->writeln(sprintf(
-            'Updated config values for environment %s',
-            $environment)
-        );
+        if ($environmentValues->isEmpty()) {
+            $output->writeln('No configuration found for environment ' . $environment);
+        } else {
+            $output->writeln(sprintf(
+                'Updated config values for environment %s',
+                $environment
+            ));
+        }
+
+
 
         return 0;
     }

--- a/test/EnvironmentConfigurationCommandTest.php
+++ b/test/EnvironmentConfigurationCommandTest.php
@@ -18,15 +18,6 @@ class EnvironmentConfigurationCommandTest extends TestCase
     /** @var EnvironmentConfigurationCommand */
     private $subject;
 
-    public function testExecuteFailure()
-    {
-        $input = $this->getMockForAbstractClass(InputInterface::class);
-        $output = $this->getMockForAbstractClass(OutputInterface::class);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->subject->execute($input, $output);
-    }
-
     public function testExecuteSuccess()
     {
         $input = $this->getMockForAbstractClass(InputInterface::class);


### PR DESCRIPTION
Different projects run in many different environments, do not be
opinionated about their names.